### PR TITLE
Improve option overriding

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Optional:
 * `iconEmoji`: Give the username an emoji as an avatar
 * `prependLevel`: set to `true` by default, sets `[level]` at the beginning of the message
 * `appendMeta`: set to `true` by default, sets stringified `meta` at the end of the message
-$ `formatter(options)`: function for transforming the message before posting to Slack
+* `formatter(options)`: function for transforming the message before posting to Slack
 
 ### Formatter
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var request = require('request');
 var winston = require('winston');
 
 var SlackHook = winston.transports.SlackHook = function (options) {
-  this.name = 'slackHook';
+  this.name = options.name || 'slackHook';
   this.level = options.level || 'info';
 
   this.username = options.username || 'bot';
@@ -12,8 +12,8 @@ var SlackHook = winston.transports.SlackHook = function (options) {
   this.channel = options.channel || '#logs';
   this.iconEmoji = options.iconEmoji || null;
 
-  this.prependLevel = options.prependLevel || true;
-  this.appendMeta = options.appendMeta || true;
+  this.prependLevel = options.prependLevel === undefined ? true : options.prependLevel;
+  this.appendMeta = options.appendMeta === undefined ? true : options.appendMeta;
 
   this.formatter = options.formatter || null;
 };
@@ -23,14 +23,14 @@ util.inherits(SlackHook, winston.Transport);
 SlackHook.prototype.log = function (level, msg, meta, callback) {
   var message = '';
 
-  if (this.prependLevel === true) {
+  if (this.prependLevel) {
     message += '[' + level + '] ';
   }
 
   message += msg;
 
   if (
-    this.appendMeta === true &&
+    this.appendMeta &&
     meta &&
     Object.getOwnPropertyNames(meta).length
   ) {


### PR DESCRIPTION
Hi, I reviewed the numerous slack winston transport modules available on npm and found yours to have the clearest and most up to date API. Would you be open to including these few small changes?

- Allow custom override of name property
- Use default for prependLevel and appendMeta only if undefined
- Fix typo in README.md

Allowing the override of the name property is the defacto method for allowing multiple instances of the same transport to be used side-by-side. See [this pull request in winston core](https://github.com/winstonjs/winston/pull/187) for an example.

With the way the module is currently written, overriding the `prependLevel` and `appendMeta` options is only possible with a value that evaluates truthy:

```javascript
new SlackHook({
  hookUrl: 'https://hooks.slack.com/services/XXX/YYY/ZZZ',
  username: 'bot',
  channel: '#logs',
  prependLevel: 'no thank you',
  appendMeta: 'I am fine, thanks',
});
```

The proposed change will default to true on omission, but will allow overrides with both falsey and truthy values. This is obviously a backwards-breaking change.

Finally, I changed what appeared to be a small formatting typo in the README.md

Thanks for considering these changes.