### PR TITLE
Add slack color options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ Optional:
 * `prependLevel`: set to `true` by default, sets `[level]` at the beginning of the message
 * `appendMeta`: set to `true` by default, sets stringified `meta` at the end of the message
 * `formatter(options)`: function for transforming the message before posting to Slack
+* `colors`: set to `{}` by default (no colors), set the color of the message given a level.
 
-### Formatter
+### Formatter and colors
 
-Messages can be formatted formatted further before posting to Slack:
+Messages can be formatted further before posting to Slack:
 
 ```js
 var logger = new Logger({
@@ -74,6 +75,12 @@ var logger = new Logger({
         // do something with the message
 
         return message;
+      },
+      colors: {
+        warn: 'warning',
+        error: 'danger',
+        info: 'good',
+        debug: '#bbddff'
       }
     })
   ]

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var SlackHook = winston.transports.SlackHook = function (options) {
   this.appendMeta = options.appendMeta === undefined ? true : options.appendMeta;
 
   this.formatter = options.formatter || null;
+  this.colors = options.colors || {};
 };
 
 util.inherits(SlackHook, winston.Transport);
@@ -23,7 +24,7 @@ util.inherits(SlackHook, winston.Transport);
 SlackHook.prototype.log = function (level, msg, meta, callback) {
   var message = '';
 
-  if (this.prependLevel) {
+  if (this.prependLevel && !this.colors[level]) {
     message += '[' + level + '] ';
   }
 
@@ -51,6 +52,14 @@ SlackHook.prototype.log = function (level, msg, meta, callback) {
     username: this.username,
     text: message
   };
+
+  if (this.colors[level]) {
+    payload.text = this.prependLevel ? level : null;
+    payload.attachments = [{
+      text: message,
+      color: this.colors[level]
+    }];
+  }
 
   if (this.iconEmoji) {
     payload.icon_emoji = this.iconEmoji; // jshint ignore:line


### PR DESCRIPTION
Add option for color message. The key should be a level message (`error`, `warn`, ....) and the value a color (hex or slack [colors](https://api.slack.com/docs/message-attachments#color))

Exemple of colors object : 

```js
colors = {
  warn: 'warning',
  error: 'danger',
  info: 'good',
  debug: '#bbddff'
}
```